### PR TITLE
Add opam files for all projects in the snarky repo

### DIFF
--- a/packages/bitstring_lib/bitstring_lib.0.1/opam
+++ b/packages/bitstring_lib/bitstring_lib.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/bitstring_lib/bitstring_lib.0.1/opam
+++ b/packages/bitstring_lib/bitstring_lib.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "bitstring_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core" {>= "v0.12" & < "v0.13" }
+  "tuple_lib"
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+A helper library for bitstrings in snarky
+"

--- a/packages/ctypes_foreign_libffi/ctypes_foreign_libffi.0.1/opam
+++ b/packages/ctypes_foreign_libffi/ctypes_foreign_libffi.0.1/opam
@@ -1,0 +1,23 @@
+opam-version: "1.2"
+name: "ctypes_foreign_libffi"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ctypes"
+  "ctypes-foreign"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+An implementation of the Ctypes.FOREIGN interface built on the libffi backend
+"
+

--- a/packages/ctypes_foreign_libffi/ctypes_foreign_libffi.0.1/opam
+++ b/packages/ctypes_foreign_libffi/ctypes_foreign_libffi.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ctypes"

--- a/packages/fold_lib/fold_lib.0.1/opam
+++ b/packages/fold_lib/fold_lib.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/fold_lib/fold_lib.0.1/opam
+++ b/packages/fold_lib/fold_lib.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "fold_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+]
+available: [ ocaml-version >= "4.07.0" ]
+descr: "
+A library for treating folds as a first-class data structure and a monad
+"

--- a/packages/fold_lib/fold_lib.0.1/opam
+++ b/packages/fold_lib/fold_lib.0.1/opam
@@ -20,7 +20,6 @@ depends: [
   "bisect_ppx"
   "dune"                {build & >= "2.0"}
 ]
-available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A library for treating folds as a first-class data structure and a monad
 "

--- a/packages/group_map/group_map.0.1/opam
+++ b/packages/group_map/group_map.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/group_map/group_map.0.1/opam
+++ b/packages/group_map/group_map.0.1/opam
@@ -1,0 +1,22 @@
+opam-version: "1.2"
+name: "group_map"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "snarkette"
+]
+descr: "
+Map from finite field elements to elliptic curves points over the finite field
+"

--- a/packages/h_list/h_list.0.1/opam
+++ b/packages/h_list/h_list.0.1/opam
@@ -1,0 +1,21 @@
+opam-version: "1.2"
+name: "h_list"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+Heterogeneous lists
+"
+

--- a/packages/h_list/h_list.0.1/opam
+++ b/packages/h_list/h_list.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "dune"                {build & >= "2.0"}

--- a/packages/interval_union/interval_union.0.1/opam
+++ b/packages/interval_union/interval_union.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/interval_union/interval_union.0.1/opam
+++ b/packages/interval_union/interval_union.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "interval_union"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+A helper library for manipulating intervals -- pairs of integers -- in snarky
+"

--- a/packages/meja/meja.0.1/opam
+++ b/packages/meja/meja.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/meja/meja.0.1/opam
+++ b/packages/meja/meja.0.1/opam
@@ -20,7 +20,6 @@ depends: [
   "ppx_jane"
   "dune"                {build & >= "2.0"}
 ]
-available: [ ocaml-version >= "4.07.1" ]
 descr: "
 A Reason-ML style language with baked-in support for Snarky
 "

--- a/packages/meja/meja.0.1/opam
+++ b/packages/meja/meja.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "meja"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ocaml-compiler-libs"
+  "ppxlib"
+  "ppx_jane"
+  "dune"                {build & >= "2.0"}
+]
+available: [ ocaml-version >= "4.07.1" ]
+descr: "
+A Reason-ML style language with baked-in support for Snarky
+"

--- a/packages/ppx_snarky/ppx_snarky.0.1/opam
+++ b/packages/ppx_snarky/ppx_snarky.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/ppx_snarky/ppx_snarky.0.1/opam
+++ b/packages/ppx_snarky/ppx_snarky.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "ppx_snarky"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core" {>= "v0.12" & < "v0.13" }
+  "ppxlib"
+  "ppx_tools"
+  "ppx_sexp_conv"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+A rewiter for Snarky
+"
+

--- a/packages/snarkette/snarkette.0.1/opam
+++ b/packages/snarkette/snarkette.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarkette/snarkette.0.1/opam
+++ b/packages/snarkette/snarkette.0.1/opam
@@ -1,0 +1,28 @@
+opam-version: "1.2"
+name: "snarkette"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "tuple_lib"
+  "fold_lib"
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+  "ppx_deriving_yojson"
+]
+descr: "
+A portable cryptography library
+"

--- a/packages/snarky/snarky.0.1/opam
+++ b/packages/snarky/snarky.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky/snarky.0.1/opam
+++ b/packages/snarky/snarky.0.1/opam
@@ -9,9 +9,9 @@ license: "MIT"
 build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
-url: [
-  src: git://github.com/o1-labs/snarky/snarky.git
-]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
 depends: [
   "core_kernel" {>= "v0.12" & < "v0.13" }
   "h_list"

--- a/packages/snarky/snarky.0.1/opam
+++ b/packages/snarky/snarky.0.1/opam
@@ -1,0 +1,41 @@
+opam-version: "1.2"
+name: "snarky"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url: [
+  src: git://github.com/o1-labs/snarky/snarky.git
+]
+depends: [
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "h_list"
+  "fold_lib"
+  "tuple_lib"
+  "bitstring_lib"
+  "interval_union"
+  "bignum"
+  "base64"
+  "yojson" {>= "1.7.0" & < "1.8.0"}
+  "ctypes" {>= "0.14" & < "0.18"}
+  "ctypes-foreign" {>= "0.4.0" & < "0.5.0"}
+  "ctypes_foreign_libffi"
+  "ppx_snarky"
+  "ppx_jane" {>= "v0.12" & < "v0.13"}
+  "ppx_deriving" {>= "4.2.1" & < "4.5"}
+  "bisect_ppx" {>= "2.0.0"}
+  "dune"                {build & >= "2.0"}
+]
+depopts: [
+  "snarky_cuda"
+]
+available: [ ocaml-version >= "4.07.0" ]
+descr: "
+A snarks DSL
+"
+

--- a/packages/snarky/snarky.0.1/opam
+++ b/packages/snarky/snarky.0.1/opam
@@ -13,6 +13,7 @@ url {
   src: "git://github.com/o1-labs/snarky/snarky.git"
 }
 depends: [
+  "ocaml" {>= "4.07.0"}
   "core_kernel" {>= "v0.12" & < "v0.13" }
   "h_list"
   "fold_lib"
@@ -34,7 +35,6 @@ depends: [
 depopts: [
   "snarky_cuda"
 ]
-available: [ ocaml-version >= "4.07.0" ]
 descr: "
 A snarks DSL
 "

--- a/packages/snarky_bench/snarky_bench.0.1/opam
+++ b/packages/snarky_bench/snarky_bench.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky_bench/snarky_bench.0.1/opam
+++ b/packages/snarky_bench/snarky_bench.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "snarky_bench"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core" {>= "v0.12" & < "v0.13" }
+  "snarky"
+  "ppx_jane"
+  "ppx_bench"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+Benchmark runner for snarky
+"

--- a/packages/snarky_curve/snarky_curve.0.1/opam
+++ b/packages/snarky_curve/snarky_curve.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky_curve/snarky_curve.0.1/opam
+++ b/packages/snarky_curve/snarky_curve.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "1.2"
+name: "snarky_curve"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+  "snarky"
+  "group_map"
+]
+descr: "
+A library for elliptic curves in snarky
+"

--- a/packages/snarky_integer/snarky_integer.0.1/opam
+++ b/packages/snarky_integer/snarky_integer.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky_integer/snarky_integer.0.1/opam
+++ b/packages/snarky_integer/snarky_integer.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "snarky_integer"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+  "snarky"
+]
+descr: "
+A library for integers in snarky
+"

--- a/packages/snarky_signature/snarky_signature.0.1/opam
+++ b/packages/snarky_signature/snarky_signature.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky_signature/snarky_signature.0.1/opam
+++ b/packages/snarky_signature/snarky_signature.0.1/opam
@@ -1,0 +1,26 @@
+opam-version: "1.2"
+name: "snarky_signature"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+  "snarky"
+]
+descr: "
+A library for signatures in snarky
+"

--- a/packages/snarky_universe/snarky_universe.0.1/opam
+++ b/packages/snarky_universe/snarky_universe.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/snarky_universe/snarky_universe.0.1/opam
+++ b/packages/snarky_universe/snarky_universe.0.1/opam
@@ -1,0 +1,32 @@
+opam-version: "1.2"
+name: "snarky_universe"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+  "snarky"
+  "snarky_integer"
+  "snarky_curve"
+  "snarky_signature"
+  "sponge"
+  "snarkette"
+  "ppx_deriving_yojson"
+]
+descr: "
+A wrapper library around snarky providing some useful modules.
+"

--- a/packages/sponge/sponge.0.1/opam
+++ b/packages/sponge/sponge.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/sponge/sponge.0.1/opam
+++ b/packages/sponge/sponge.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "sponge"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+A library implementing the arithmetic sponge construction and several sponge-based hash functions
+"

--- a/packages/tuple_lib/tuple_lib.0.1/opam
+++ b/packages/tuple_lib/tuple_lib.0.1/opam
@@ -10,7 +10,7 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 url {
-  src: "git://github.com/o1-labs/snarky/snarky.git"
+  src: "git://github.com/o1-labs/snarky.git"
 }
 depends: [
   "ocaml" {>= "4.07.0"}

--- a/packages/tuple_lib/tuple_lib.0.1/opam
+++ b/packages/tuple_lib/tuple_lib.0.1/opam
@@ -1,0 +1,25 @@
+opam-version: "1.2"
+name: "tuple_lib"
+maintainer: "opensource@o1labs.org"
+authors: ["O(1) Labs, LLC <opensource@o1labs.org>"]
+homepage: "https://github.com/o1labs/snarky"
+bug-reports: "https://github.com/o1labs/snarky/issues"
+dev-repo: "git+https://github.com/o1labs/snarky.git"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+url {
+  src: "git://github.com/o1-labs/snarky/snarky.git"
+}
+depends: [
+  "ocaml" {>= "4.07.0"}
+  "core_kernel" {>= "v0.12" & < "v0.13" }
+  "ppx_deriving"
+  "ppx_jane"
+  "bisect_ppx"
+  "dune"                {build & >= "2.0"}
+]
+descr: "
+A tiny library with names and a useful getter for tuples
+"


### PR DESCRIPTION
These were ported over from the opam files in the snarky repo (modified versions from o1-labs/snarky#560). Bash one-liner to repeat the update:
```
for i in /path/to/snarky/*.opam; do NAME=$(basename ${i%.*}); mkdir -p packages/$NAME/$NAME.0.1; cp $i packages/$NAME/$NAME.0.1/opam; done
```

All packages are arbitrarily set to version 0.1 for now.