### PR TITLE
[new release] ppx_version (0.1)

### DIFF
--- a/packages/ppx_version/ppx_version.0.1/opam
+++ b/packages/ppx_version/ppx_version.0.1/opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+authors: "opensource@o1labs.org"
+homepage: "https://github.com/o1-labs/ppx_version"
+bug-reports: "opensource@o1labs.org"
+dev-repo: "git+https://github.com/o1-labs/ppx_version.git"
+maintainer: "opensource@o1labs.org"
+depends: [
+  "ocaml" {<= "4.07.1"}
+  "ppxlib"
+  "ppx_bin_prot"
+  "core_kernel" {< "v0.13"}
+  "dune" {>= "2.5"}
+]
+build: ["dune" "build" "-p" name "-j" jobs]
+x-commit-hash: "f0baefe11ee27030df6537f481bccf849a4c6d76"
+synopsis:
+  "Ocaml extension point (ppx) meant to assure the stability of types and their Bin_prot serializations"
+description:
+  "See the readme at https://github.com/o1-labs/ppx_version/README.md for more information."
+url {
+  src:
+    "https://github.com/o1-labs/ppx_version/releases/download/0.1/ppx_version-0.1.tbz"
+  checksum: [
+    "sha256=2698d6e3db3ee49d9cecee80bf2a363ece2f8bd932bdd7038ee4730ebbd3ae5e"
+    "sha512=4a941a3c9eb4c7aa0a2910abd3768770be2cc1789af18898083ef990d229d3f50802ce67fd53b2c84ba38a07d65a1b8c6f0aabcb31f5d6f4ca4e158d13d7a98c"
+  ]
+}


### PR DESCRIPTION
Ocaml extension point (ppx) meant to assure the stability of types and their Bin_prot serializations

- Project page: <a href="https://github.com/o1-labs/ppx_version">https://github.com/o1-labs/ppx_version</a>

##### CHANGES:

First release.
