### PR TITLE
chore: add pin for async_ssl version

### DIFF
--- a/packages/async_ssl/async_ssl.v0.14.0-o1labs/opam
+++ b/packages/async_ssl/async_ssl.v0.14.0-o1labs/opam
@@ -1,0 +1,34 @@
+opam-version: "2.0"
+version: "v0.14.0-o1labs"
+maintainer: "leon@o1labs.org"
+authors: ["Jane Street Group, LLC <opensource@janestreet.com>"]
+homepage: "https://github.com/janestreet/async_ssl"
+bug-reports: "https://github.com/janestreet/async_ssl/issues"
+dev-repo: "git+https://github.com/janestreet/async_ssl.git"
+doc: "https://ocaml.janestreet.com/ocaml-core/latest/doc/async_ssl/index.html"
+license: "MIT"
+build: [
+  ["dune" "build" "-p" name "-j" jobs]
+]
+depends: [
+  "ocaml"             {>= "4.08.0"}
+  "async"             {>= "v0.14" & < "v0.15"}
+  "base"              {>= "v0.14" & < "v0.15"}
+  "core"              {>= "v0.14" & < "v0.15"}
+  "ppx_jane"          {>= "v0.14" & < "v0.15"}
+  "stdio"             {>= "v0.14" & < "v0.15"}
+  "conf-openssl"
+  "ctypes"            {>= "0.16.0"}
+  "ctypes-foreign"
+  "dune"              {>= "2.0.0"}
+  "dune-configurator"
+]
+synopsis: "An Async-pipe-based interface with OpenSSL"
+description: "
+This library allows you to create an SSL client and server, with
+encrypted communication between both.
+"
+url {
+  src: "https://github.com/o1-labs/async_ssl/archive/v0.14-o1labs.tar.gz"
+  checksum: "sha256=2a40cb172f382d41b3503911486138217772c87b21ce459e9e708377b8e77070"
+}


### PR DESCRIPTION
For MacOS builds, openssl prefers to be upgraded (at least past 1.1). I'm adding this custom package to the list because it makes minimal changes to the packages while also allowing us to build cleanly on MacOS.

This is in lieu of upgrading async_ssl directly, since that comes with a whole swathe of other upgrades.

The relevant changes here are mainly some removed symbols (these changes are also reflected in newer versions of async_ssl, I just back-ported them to my own fork, and then pushed the changes up to the more widely used "florian fork").

Tested these changes by using:

`opam repository add .` in this working directory.

then `opam install async_ssl.v0.14.0-o1labs`.

I'd also like to propose the `-o1labs` suffix for pinned packages such as these, to indicate in our opam exports which packages we pin as an organization, just so its clear to anyone that hits their head, where to look for assistance. (instead of the `.dev` suffix that is common for one-off patches).