### PR TITLE
add rocksdb 10.5.1 and make it compatible with rocks 0.2.0

### DIFF
--- a/packages/rocks/rocks.0.2.0/opam
+++ b/packages/rocks/rocks.0.2.0/opam
@@ -8,7 +8,7 @@ depends: [
   "ocamlbuild" {build}
   "ctypes" {>= "0.4.0"}
   "ctypes-foreign" {>= "0.4.0"}
-  "rocksdb_stubs" {>= "10.2.1"}
+  "rocksdb_stubs" {>= "10.2.1" & <= "10.5.1"}
   "core"
 ]
 url {

--- a/packages/rocksdb_stubs/rocksdb_stubs.10.5.1/opam
+++ b/packages/rocksdb_stubs/rocksdb_stubs.10.5.1/opam
@@ -1,0 +1,20 @@
+opam-version: "2.0"
+version: "10.5.1"
+# Contents of extra source: 'stublibs: ["librocksdb_stubs.a"]'
+extra-source "rocksdb_stubs.install" {
+  src: "https://gist.githubusercontent.com/georgeee/80966c56448bd9a6f453a0ffa3c10f60/raw/23024b7ef940f84cf95523d77da7d27b4c3ccdc8/rocksdb_stubs.install"
+  checksum: "sha256=c6450141e1d8b4ad2034a6704fc8902e50f9ac28c66a490c2b460e7a23f63b7a"
+}
+build: [
+  [ "bash" "-c"
+    "if [ -e ${MINA_ROCKSDB-/usr/local/lib/librocksdb_coda.a} ]; then cp ${MINA_ROCKSDB-/usr/local/lib/librocksdb_coda.a} librocksdb.a; chmod 666 librocksdb.a; else ROCKSDB_DISABLE_SNAPPY=1 ROCKSDB_DISABLE_GFLAGS=1 ROCKSDB_DISABLE_LZ4=1 ROCKSDB_DISABLE_ZSTD=1 ROCKSDB_DISABLE_NUMA=1 ROCKSDB_DISABLE_TBB=1 ROCKSDB_DISABLE_JEMALLOC=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_BACKTRACE=1 ROCKSDB_USE_IO_URING=0 PORTABLE=1 FORCE_SSE42=1 DISABLE_WARNING_AS_ERROR=1 make static_lib -j8; fi"
+  ]
+  ["strip" "-S" "librocksdb.a"]
+  ["mv" "librocksdb.a" "librocksdb_stubs.a"]
+]
+url {
+  src:
+    "https://github.com/facebook/rocksdb/archive/refs/tags/v10.5.1.tar.gz"
+  checksum:
+    "sha256=7ec942baab802b2845188d02bc5d4e42c29236e61bcbc08f5b3a6bdd92290c22"
+}


### PR DESCRIPTION
As title. This is so we can ensure nix & docker are building with same rocksdb version